### PR TITLE
fix: 🐛 `hash` is actually `sha`

### DIFF
--- a/org/all-prs.js
+++ b/org/all-prs.js
@@ -113,7 +113,7 @@ exports.packageLockChange = () =>
 const noAssignee = () => !danger.github.pr.assignee;
 const atLeastNReviewers = n => danger.github.requested_reviewers.length < n;
 const authorMatchesBranchPrefix = () =>
-  danger.github.pr.base.ref.startsWith(`${danger.github.pr.user.login}/`);
+  danger.github.pr.head.ref.startsWith(`${danger.github.pr.user.login}/`);
 
 exports.noReviewers = () =>
   atLeastNReviewers(1)
@@ -123,7 +123,7 @@ exports.noReviewers = () =>
 exports.authorPrefix = () =>
   !authorMatchesBranchPrefix()
     ? warn(`Please rename your base branch so it has your username as a prefix:
-    \`git checkout -b ${danger.github.pr.user.login}/${danger.github.pr.base.ref}\``)
+    \`git checkout -b ${danger.github.pr.user.login}/${danger.github.pr.head.ref}\``)
     : ok('authorPrefix');
 
 exports.assignee = () =>

--- a/org/all-prs.js
+++ b/org/all-prs.js
@@ -8,6 +8,7 @@ const {
   filter,
   isEmpty,
   split,
+  head,
   ap,
   of,
   none,
@@ -112,8 +113,13 @@ exports.packageLockChange = () =>
 
 const noAssignee = () => !danger.github.pr.assignee;
 const atLeastNReviewers = n => danger.github.requested_reviewers.length < n;
-const authorMatchesBranchPrefix = () =>
-  danger.github.pr.head.ref.startsWith(`${danger.github.pr.user.login}/`);
+const authorMatchesBranchPrefix = () => {
+  const parts = split('/', danger.github.pr.head.ref);
+  const login = danger.github.pr.user.login.toLowerCase();
+  const prefix = head(parts).toLowerCase();
+  // allow for substring of login
+  return parts.length >= 2 && prefix.length >= 2 && contains(prefix, login);
+};
 
 exports.noReviewers = () =>
   atLeastNReviewers(1)

--- a/org/all-prs.js
+++ b/org/all-prs.js
@@ -41,7 +41,7 @@ const commitTypes = [
   'revert:',
 ];
 
-const linkForCommit = commit => `[${commit.hash.slice(0, 6)}](${commit.url})`;
+const linkForCommit = commit => `[${commit.sha.slice(0, 6)}](${commit.url})`;
 
 const commitMsg = prop('message');
 

--- a/org/commits.test.js
+++ b/org/commits.test.js
@@ -17,13 +17,13 @@ const setCommits = commits => global.danger = {git: {commits}};
 
 const buildCommit = (
   message,
-  hash = '66d8911a91facb389504a6774e4cf5538fed243e',
+  sha = '66d8911a91facb389504a6774e4cf5538fed243e',
   author = 'Esteban',
 ) => ({
-  hash,
+  sha,
   author,
   message,
-  url: `https://github.com/wearereasonablepeople/RepoCop/pull/123/commits/${hash}`,
+  url: `https://github.com/wearereasonablepeople/RepoCop/pull/123/commits/${sha}`,
 });
 
 describe('lineLength', () => {

--- a/org/people.test.js
+++ b/org/people.test.js
@@ -17,7 +17,8 @@ const setReviewers = rs => global.danger = {github: {requested_reviewers: rs}};
 const setPrMeta = (ref, login, assignee) => global.danger = {github: {pr: {
   user: {login},
   assignee,
-  base: {ref}
+  head: {ref},
+  base: {ref: 'master'},
 }}};
 
 describe('reviewers', () => {

--- a/org/people.test.js
+++ b/org/people.test.js
@@ -46,6 +46,11 @@ describe('branch name', () => {
     authorPrefix();
     expect(global.warn).not.toBeCalled();
   });
+  it('should accept parts of author name', () => {
+    setPrMeta('denver/branch-name', 'DenverCoder9');
+    authorPrefix();
+    expect(global.warn).not.toBeCalled();
+  });
 });
 
 describe('assignee', () => {


### PR DESCRIPTION
# Motivation
Runtime error on running the dangerfile

# Changes
- fix `hash` to `sha`
- Fix prefix message
- Add support for substring for logins
