### PR TITLE
Turn peril on for all repos (it can get to!)

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -7,15 +7,7 @@
     ],
     "env_vars": []
   },
-  "repos" : {
-    "wearereasonablepeople/RepoCop": {
-      "pull_request": "wearereasonablepeople/peril-settings@org/all-prs.js"
-    },
-    "wearereasonablepeople/template": {
-      "pull_request": "wearereasonablepeople/peril-settings@org/all-prs.js"
-    },
-    "wearereasonablepeople/peril-settings": {
-      "pull_request": "wearereasonablepeople/peril-settings@org/all-prs.js"
-    }
+  "rules": {
+    "pull_request": "wearereasonablepeople/peril-settings@org/all-prs.js"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Turns peril on for everyone

# Motivation
:zap: :zap: :zap: :zap:

# Changes
- Move rules from the testing repos to the whole org.