### PR TITLE
Ignore merge commits on commit text checks

### DIFF
--- a/org/commits.test.js
+++ b/org/commits.test.js
@@ -46,6 +46,16 @@ describe('lineLength', () => {
     lineLength();
     expect(global.fail).not.toBeCalled();
   });
+
+  it('should ignore merge commits', () => {
+    setCommits([
+      //eslint-disable-next-line max-len
+      buildCommit('Merge pull request #42 from wearereasonablepeople/OurOrgNameIsAlreadyPrettyLong/so-merge-commits-can-be-huge')
+    ]);
+
+    lineLength();
+    expect(global.fail).not.toBeCalled();
+  });
 });
 
 describe('format', () => {
@@ -66,6 +76,16 @@ describe('format', () => {
     ]);
 
     typePrefix();
+    expect(global.warn).not.toBeCalled();
+  });
+  it('should ignore Merge commits', () => {
+    setCommits([
+      buildCommit('Merge pull request #42 from wearereasonablepeople/anyone/do-stuff'),
+      buildCommit('feat: a prefix'),
+    ]);
+
+    typePrefix();
+    expect(global.fail).not.toBeCalled();
     expect(global.warn).not.toBeCalled();
   });
 });


### PR DESCRIPTION
# Motivation
Merge commits are generated by tooling so they should be ignored by danger rules

# Changes
<!-- A few points describing the set of changes included on this pull request. -->
- Ignore merge commits from relevant checks
- Add unit tests
- Sort ramda imports alphabetically

<!-- e.g.
- [UI] Change the style of widget so it's 1px higher
- [Style] Make all statements in code have 1 blank line between them :tada:
-->

# Verification steps
- See added unit tests