### PR TITLE
fix: 🐛 change motivation header check to warn()

### DIFF
--- a/org/all-prs.js
+++ b/org/all-prs.js
@@ -142,7 +142,7 @@ const missingMdHeader = header => !(new RegExp(`^#+ *${header}`, 'mi')).test(dan
 
 exports.missingMotivationHeader = () =>
   missingMdHeader('Motivation')
-    ? fail('Please include a Motivation section')
+    ? warn('Please include a Motivation section')
     : ok('missingMotivationHeader');
 exports.missingChangesHeader = () =>
   missingMdHeader('Changes')

--- a/org/pr-body.test.js
+++ b/org/pr-body.test.js
@@ -18,7 +18,7 @@ describe('PR body headers', () => {
   it('should require "Motivation"', () => {
     setPrBody('Fixes: #1234');
     missingMotivationHeader();
-    expect(global.fail).toBeCalled();
+    expect(global.warn).toBeCalled();
   });
   it('should suggest "Changes"', () => {
     setPrBody('Fixes: #1234');


### PR DESCRIPTION
# Motivation
<!-- Add a description of the motivation for the PR’s changes or just a link to the related issue -->
Fixes #9
The BP document is not as strict as this check

# Changes
<!-- A few points describing the set of changes included on this pull request. -->
- Change reporting level for `# Motivation` to warn()
