### PR TITLE
Improvements / bug fixes

### DIFF
--- a/org/all-prs.js
+++ b/org/all-prs.js
@@ -60,7 +60,7 @@ const approvedVerbs = [
   'Release',
 ];
 
-const linkForCommit = commit => `[${commit.sha.slice(0, 6)}](${commit.url})`;
+const linkForCommit = commit => `[\`${commit.sha.slice(0, 6)}\`](${commit.html_url})`;
 const commitMsg = prop('message');
 const excludeMergeCommits = reject(compose(startsWith('Merge'), commitMsg));
 const R_ALPHA = /[a-zA-Z0-9]/;

--- a/org/all-prs.js
+++ b/org/all-prs.js
@@ -63,7 +63,7 @@ const approvedVerbs = [
 const linkForCommit = commit => `[\`${commit.sha.slice(0, 6)}\`](${commit.html_url})`;
 const commitMsg = prop('message');
 const excludeMergeCommits = reject(compose(startsWith('Merge'), commitMsg));
-const R_ALPHA = /[a-zA-Z0-9]/;
+const R_PUNCTUATION = /[.?!]/;
 
 exports.tests = {
 
@@ -121,10 +121,10 @@ exports.tests = {
     critical: true,
     test: pipe(
       path(['git', 'commits']),
-      reject(pipe(commitMsg, split('\n'), head, last, x => R_ALPHA.test(x))),
+      filter(pipe(commitMsg, split('\n'), head, last, x => R_PUNCTUATION.test(x))),
       map(linkForCommit),
       map(commit => (
-        `Message header for commit ${commit} must end in an alphanumerical character.`
+        `Message header for commit ${commit} must not end with punctuation.`
       )),
     ),
   }

--- a/org/commits.test.js
+++ b/org/commits.test.js
@@ -9,17 +9,18 @@ const mockCommit = (message, sha = '66d8911a', author = 'Esteban') => ({
   sha,
   author,
   message,
-  url: `./commits/${sha}`,
+  //eslint-disable-next-line camelcase
+  html_url: `./commits/${sha}`,
 });
 
 const noApprovedVerb = (
-  'Message for commit [66d891](./commits/66d8911a) starts with an uncommon verb, ' +
+  'Message for commit [`66d891`](./commits/66d8911a) starts with an uncommon verb, ' +
   'consider using one of: Add, Remove, Fix, Test, Document, Refactor, Style, ' +
   'Revert, Update, Configure, Deprecate, Correct, Improve, Initialise, Merge, Release.'
 );
 
 const noVerb = (
-  'Message for commit [66d891](./commits/66d8911a) must start with an imperative verb.'
+  'Message for commit [`66d891`](./commits/66d8911a) must start with an imperative verb.'
 );
 
 const testAssertions = {
@@ -43,7 +44,7 @@ const testAssertions = {
     {fixture: mockDanger([]), expected: []},
     {fixture: mockDanger([mockCommit('small message')]), expected: []},
     {fixture: mockDanger([mockCommit(repeat('lo', 100).join())]), expected: [
-      'Commit [66d891](./commits/66d8911a) has lines with over 70 characters.'
+      'Commit [`66d891`](./commits/66d8911a) has lines with over 70 characters.'
     ]}
   ],
 
@@ -52,7 +53,7 @@ const testAssertions = {
     {fixture: mockDanger([mockCommit('foo bar')]), expected: []},
     {fixture: mockDanger([mockCommit('!@#$%^&*(){}[]')]), expected: []},
     {fixture: mockDanger([mockCommit('feat: 💩 I like emoji!!!')]), expected: [
-      'Message header for commit [66d891](./commits/66d8911a) must contain ASCII characters only.'
+      'Message header for commit [`66d891`](./commits/66d8911a) must contain ASCII characters only.'
     ]},
   ],
 
@@ -60,7 +61,7 @@ const testAssertions = {
     {fixture: mockDanger([]), expected: []},
     {fixture: mockDanger([mockCommit('foo bar')]), expected: []},
     {fixture: mockDanger([mockCommit('feat: 💩 I like emoji!!!')]), expected: [
-      'Message header for commit [66d891](./commits/66d8911a) must ' +
+      'Message header for commit [`66d891`](./commits/66d8911a) must ' +
       'end in an alphanumerical character.'
     ]},
   ],

--- a/org/commits.test.js
+++ b/org/commits.test.js
@@ -60,9 +60,10 @@ const testAssertions = {
   commitMessagePunctuation: [
     {fixture: mockDanger([]), expected: []},
     {fixture: mockDanger([mockCommit('foo bar')]), expected: []},
+    {fixture: mockDanger([mockCommit('Merge branch "master" into "production"')]), expected: []},
     {fixture: mockDanger([mockCommit('feat: 💩 I like emoji!!!')]), expected: [
       'Message header for commit [`66d891`](./commits/66d8911a) must ' +
-      'end in an alphanumerical character.'
+      'not end with punctuation.'
     ]},
   ],
 };


### PR DESCRIPTION
# Motivation

The rule about punctuation was overzealous, as it would reject for example: `Merge branch "master" into "production"`, for the commit message ending in `"`. I also fixed the wrong commit links.

# Changes

:point_down: 