### PR TITLE
Relax the rule about commit body length

### DIFF
--- a/org/all-prs.js
+++ b/org/all-prs.js
@@ -28,6 +28,7 @@ const {
   reject,
   split,
   startsWith,
+  tail,
   toPairs,
 } = require('ramda');
 
@@ -91,15 +92,28 @@ exports.tests = {
     ),
   },
 
-  commitMessageLength: {
+  commitHeaderLength: {
     critical: true,
     test: pipe(
       path(['github', 'commits']),
       excludeMergeCommits,
-      filter(pipe(commitMsg, split('\n'), any(x => x.length > 70))),
+      filter(pipe(commitMsg, split('\n'), head, x => x.length > 70)),
       map(linkForCommit),
       map(commit => (
-        `Commit ${commit} has lines with over 70 characters.`
+        `Commit ${commit} has a header with over 70 characters.`
+      )),
+    )
+  },
+
+  commitBodyLength: {
+    critical: false,
+    test: pipe(
+      path(['github', 'commits']),
+      excludeMergeCommits,
+      filter(pipe(commitMsg, split('\n'), tail, any(x => x.length > 80))),
+      map(linkForCommit),
+      map(commit => (
+        `Commit ${commit} has a body with lines over 80 characters.`
       )),
     )
   },

--- a/org/commits.test.js
+++ b/org/commits.test.js
@@ -42,11 +42,19 @@ const testAssertions = {
     {fixture: mockDanger([mockCommit('feat: 💩 I like emoji!!!')]), expected: [noVerb]},
   ],
 
-  commitMessageLength: [
+  commitHeaderLength: [
     {fixture: mockDanger([]), expected: []},
     {fixture: mockDanger([mockCommit('small message')]), expected: []},
     {fixture: mockDanger([mockCommit(repeat('lo', 100).join())]), expected: [
-      'Commit [`66d891`](./commits/66d8911a) has lines with over 70 characters.'
+      'Commit [`66d891`](./commits/66d8911a) has a header with over 70 characters.'
+    ]}
+  ],
+
+  commitBodyLength: [
+    {fixture: mockDanger([]), expected: []},
+    {fixture: mockDanger([mockCommit('small message\n\nsmall body')]), expected: []},
+    {fixture: mockDanger([mockCommit(`small message\n\n${repeat('lo', 100).join()}`)]), expected: [
+      'Commit [`66d891`](./commits/66d8911a) has a body with lines over 80 characters.'
     ]}
   ],
 


### PR DESCRIPTION
# Motivation

Commit body rule is too strict: it does not allow for cases such as links in the commit body, and the 70 char limit does not apply (the body is not truncated by GitHub)

# Changes

- Turn it from error to warning
- Extend it from a limit of 70 to a limit of 80 characters
